### PR TITLE
Change way to create condition in where statements

### DIFF
--- a/classes/contracts/i_condition.php
+++ b/classes/contracts/i_condition.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sqlquerybuilder\contracts;
+
+/**
+ * Builds an where expression without WHERE
+ *
+ * @package     local_sqlquerybuilder
+ * @copyright   2025 Konrad Ebel <despair2400@proton.me>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+interface i_condition extends i_expression {
+    public function where(string $column, string $operator, mixed $value): i_condition;
+    public function where_column(string $column, string $operator, string $othercolumn): i_condition;
+    public function or_where(string $column, string $operator, mixed $value): i_condition;
+    public function where_not(string $column, string $operator, mixed $value): i_condition;
+    public function or_where_not(string $column, string $operator, mixed $value): i_condition;
+    public function where_fulltext(string $column, string $value): i_condition;
+    public function where_fulltext_not(string $column, string $value): i_condition;
+    public function where_like(string $column, string $value, ?like_options $options = null): i_condition;
+    public function where_not_like(string $column, string $value, ?like_options $options = null): i_condition;
+    public function where_null(string $column): i_condition;
+    public function or_where_null(string $column): i_condition;
+    public function where_notnull(string $column): i_condition;
+    public function or_where_notnull(string $column): i_condition;
+    public function where_in(string $column, array|i_query $values, bool $negate = false): i_condition;
+    public function where_not_in(string $column, array|i_query $values): i_condition;
+    public function where_currently_active(string $columntimestart, string $columntimeend): i_condition;
+}

--- a/classes/contracts/like_options.php
+++ b/classes/contracts/like_options.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
-namespace local_sqlquerybuilder\query\where;
+namespace local_sqlquerybuilder\contracts;
 
 /**
  * Options to compare two strings

--- a/classes/local/dependency_declarations.php
+++ b/classes/local/dependency_declarations.php
@@ -18,7 +18,9 @@ namespace local_sqlquerybuilder\local;
 
 use core\hook\di_configuration;
 use local_sqlquerybuilder\contracts\i_db;
+use local_sqlquerybuilder\contracts\i_condition;
 use local_sqlquerybuilder\query\database;
+use local_sqlquerybuilder\query\condition;
 
 /**
  * Defines the dependencies for this plugin
@@ -34,6 +36,14 @@ class dependency_declarations {
             id: i_db::class,
             definition: function (): i_db {
                 return new database();
+            }
+        );
+
+        // Define i_condition
+        $hook->add_definition(
+            id: i_condition::class,
+            definition: function (): i_condition {
+                return new condition();
             }
         );
     }

--- a/classes/local/dependency_declarations.php
+++ b/classes/local/dependency_declarations.php
@@ -39,7 +39,7 @@ class dependency_declarations {
             }
         );
 
-        // Define i_condition
+        // Define i_condition.
         $hook->add_definition(
             id: i_condition::class,
             definition: function (): i_condition {

--- a/classes/query/condition.php
+++ b/classes/query/condition.php
@@ -31,7 +31,7 @@ use local_sqlquerybuilder\query\where\where_in;
 use local_sqlquerybuilder\query\where\where_like;
 
 /**
- * Builds an where expression (Including WHERE itself).
+ * Builds an where expression without WHERE
  *
  * @package     local_sqlquerybuilder
  * @copyright   2025 Konrad Ebel <despair2400@proton.me>

--- a/classes/query/condition.php
+++ b/classes/query/condition.php
@@ -1,0 +1,154 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_sqlquerybuilder\query;
+
+use core\clock;
+use core\di;
+use local_sqlquerybuilder\contracts\i_query;
+use local_sqlquerybuilder\contracts\i_expression;
+use local_sqlquerybuilder\query\where\like_options;
+use local_sqlquerybuilder\query\where\where_column_comparison;
+use local_sqlquerybuilder\query\where\where_expression;
+use local_sqlquerybuilder\query\where\where_comparison;
+use local_sqlquerybuilder\query\where\or_where_group;
+use local_sqlquerybuilder\query\where\where_fulltext;
+use local_sqlquerybuilder\query\where\where_is_null;
+use local_sqlquerybuilder\query\where\where_in;
+use local_sqlquerybuilder\query\where\where_like;
+
+/**
+ * Builds an where expression (Including WHERE itself).
+ *
+ * @package     local_sqlquerybuilder
+ * @copyright   2025 Konrad Ebel <despair2400@proton.me>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class condition implements i_expression {
+    protected array $conditionparts = [];
+
+    public function where(string $column, string $operator, mixed $value, bool $negate = false): void {
+        if ($operator == 'like') {
+            $this->conditionparts[] = new where_like($column, $value, $negate);
+        } else {
+            $this->conditionparts[] = new where_comparison($column, $operator, $value, $negate);
+        }
+    }
+
+    public function where_column(string $column, string $operator, string $othercolumn, bool $negate = false): void {
+        $this->conditionparts[] = new where_column_comparison($column, $operator, $othercolumn, $negate);
+    }
+
+    public function or_where(string $column, string $operator, mixed $value, bool $negate = false): void {
+        $this->where($column, $operator, $value, $negate);
+        $this->combine_last_two_by_or();
+    }
+
+    public function where_not(string $column, string $operator, mixed $value): void {
+        $this->where($column, $operator, $value, true);
+    }
+
+    public function or_where_not(string $column, string $operator, mixed $value): void {
+        $this->or_where($column, $operator, $value, true);
+    }
+
+    public function where_fulltext(string $column, string $value, bool $negate = false): void {
+        $this->conditionparts[] = new where_fulltext($column, $value, $negate);
+    }
+
+    public function where_fulltext_not(string $column, string $value): void {
+        $this->conditionparts[] = new where_fulltext($column, $value, true);
+    }
+
+    public function where_like(string $column, string $value, ?like_options $options = null, bool $negate = false): void {
+        $this->conditionparts[] = new where_like($column, $value, $negate, $options);
+    }
+
+    public function where_not_like(string $column, string $value, ?like_options $options = null): void {
+        $this->where_like($column, $value, $options, true);
+    }
+
+    public function where_null(string $column): void {
+        $this->conditionparts[] = new where_is_null($column);
+    }
+
+    public function or_where_null(string $column): void {
+        $this->where_null($column);
+        $this->combine_last_two_by_or();
+    }
+
+    public function where_notnull(string $column): void {
+        $this->conditionparts[] = new where_is_null($column, true);
+    }
+
+    public function or_where_notnull(string $column): void {
+        $this->where_notnull($column);
+        $this->combine_last_two_by_or();
+    }
+
+    public function where_in(string $column, array|i_query $values, bool $negate = false): void {
+        $this->conditionparts[] = new where_in($column, $values, $negate);
+    }
+
+    public function where_not_in(string $column, array|i_query $values): void {
+        $this->where_in($column, $values, true);
+    }
+
+    private function combine_last_two_by_or(): void {
+        if (count($this->conditionparts) < 2) {
+            return;
+        }
+
+        $aclause = array_pop($this->conditionparts);
+        $bclause = array_pop($this->conditionparts);
+        $orclause = null;
+
+        if ($aclause instanceof or_where_group) {
+            $aclause->add_clauses($bclause);
+            $orclause = $aclause;
+        } else {
+            $orclause = new or_where_group(
+                $aclause,
+                $bclause,
+            );
+        }
+
+        $this->conditionparts[] = $orclause;
+    }
+
+    public function where_currently_active(string $columntimestart, string $columntimeend): void {
+        $currenttime = di::get(clock::class)->time();
+
+        $this->where_null($columntimestart);
+        $this->or_where($columntimestart, '<=', $currenttime);
+        $this->where_null($columntimeend);
+        $this->or_where($columntimeend, '>=', $currenttime);
+    }
+
+    public function get_sql(): string {
+        if (empty($this->conditionparts)) {
+            return '';
+        }
+
+        $sqlclause = implode(' AND ', $this->conditionparts);
+        return $sqlclause;
+    }
+
+    public function get_params(): array {
+        $params = array_map(fn (where_expression $expression) => $expression->get_params(), $this->conditionparts);
+        return array_merge(...$params);
+    }
+}

--- a/classes/query/joinpart.php
+++ b/classes/query/joinpart.php
@@ -33,56 +33,36 @@ class joinpart implements i_expression {
     /** @var join_expression[] All join expressions for the request */
     protected array $joins = [];
 
-    private function parse_conditions($conditions) {
+    private function parse_condition(array $condition): condition {
+        $parsedcondition = new condition();
+
         // Handle single condition.
-        if (!is_array($conditions) || (count($conditions) == 3 && !is_array($conditions[0]))) {
-            return [['condition' => $conditions, 'logic' => null]];
+        if (count($condition) == 3) {
+            $parsedcondition->where_column($condition[0], $condition[1], $condition[2]);
+            return $parsedcondition;
         }
 
-        $parsed = [];
-        $currentlogic = null;
-
-        foreach ($conditions as $item) {
-            if (is_string($item) && (strtoupper($item) === 'AND' || strtoupper($item) === 'OR')) {
-                // This is a logic operator.
-                $currentlogic = strtoupper($item);
-            } else if (is_array($item) && count($item) >= 3) {
-                // This is a condition.
-                $parsed[] = ['condition' => $item, 'logic' => $currentlogic];
-                $currentlogic = 'AND'; // Default for next condition if not specified.
-            }
-        }
-
-        // If no parsed conditions, try the old format (array of arrays, all AND).
-        if (empty($parsed)) {
-            foreach ($conditions as $condition) {
-                if (is_array($condition) && count($condition) >= 3) {
-                    $parsed[] = ['condition' => $condition, 'logic' => count($parsed) === 0 ? null : 'AND'];
-                }
-            }
-        }
-
-        return $parsed;
+        throw new ValueError("Condition should have length of 3: " . var_export($condition, true));
     }
 
-    public function join(string|i_query $table, $conditions, string $alias = '') {
-        $this->joins[] = [$table, $this->parse_conditions($conditions), join_types::INNER, $alias];
+    public function join(string|i_query $table, array $condition, string $alias = '') {
+        $this->joins[] = [$table, $this->parse_condition($condition), join_types::INNER, $alias];
     }
 
-    public function left_join(string|i_query $table, $conditions, string $alias = '') {
-        $this->joins[] = [$table, $this->parse_conditions($conditions), join_types::LEFT, $alias];
+    public function left_join(string|i_query $table, array $condition, string $alias = '') {
+        $this->joins[] = [$table, $this->parse_condition($condition), join_types::LEFT, $alias];
     }
 
-    public function right_join(string|i_query $table, $conditions, string $alias = '') {
-        $this->joins[] = [$table, $this->parse_conditions($conditions), join_types::RIGHT, $alias];
+    public function right_join(string|i_query $table, array $condition, string $alias = '') {
+        $this->joins[] = [$table, $this->parse_condition($condition), join_types::RIGHT, $alias];
     }
 
-    public function full_join(string $table, $conditions, string $alias = '') {
-        $this->joins[] = [$table, $this->parse_conditions($conditions), join_types::FULL, $alias];
+    public function full_join(string $table, array $condition, string $alias = '') {
+        $this->joins[] = [$table, $this->parse_condition($condition), join_types::FULL, $alias];
     }
 
-    public function crossjoin(string $table, $conditions, string $alias = '') {
-        $this->joins[] = [$table, $this->parse_conditions($conditions), join_types::CROSS, $alias];
+    public function crossjoin(string $table, array $condition, string $alias = '') {
+        $this->joins[] = [$table, $this->parse_condition($condition), join_types::CROSS, $alias];
     }
 
     public function get_sql(): string {
@@ -93,7 +73,7 @@ class joinpart implements i_expression {
 
         foreach ($this->joins as $join) {
             $table = $join[0];
-            $parsedconditions = $join[1];
+            $condition = $join[1];
             $jointype = $join[2];
             $alias = $join[3];
 
@@ -105,23 +85,7 @@ class joinpart implements i_expression {
             }
 
             // Build the conditions part with proper AND/OR logic.
-            $conditionparts = [];
-            foreach ($parsedconditions as $parsedcondition) {
-                $condition = $parsedcondition['condition'];
-                $logic = $parsedcondition['logic'];
-
-                if (is_array($condition) && count($condition) >= 3) {
-                    $conditionstr = $condition[0] . ' ' . $condition[1] . ' ' . $condition[2];
-
-                    if ($logic && !empty($conditionparts)) {
-                        $conditionparts[] = $logic . ' ' . $conditionstr;
-                    } else {
-                        $conditionparts[] = $conditionstr;
-                    }
-                }
-            }
-
-            $joinclause .= implode(' ', $conditionparts) . ' ';
+            $joinclause .= $condition->get_sql();
         }
 
         return preg_replace('/\s{2,}/', ' ', trim($joinclause));

--- a/classes/query/orderby.php
+++ b/classes/query/orderby.php
@@ -64,7 +64,7 @@ class orderby implements i_expression {
 
         $formattedorderings = array_map(fn (ordering $order) => $order->get_sql(), $this->orderings);
 
-        return "ORDER BY " . implode(', ', $formattedorderings);
+        return ' ORDER BY ' . implode(', ', $formattedorderings);
     }
 
     public function get_params(): array {

--- a/classes/query/where/where_like.php
+++ b/classes/query/where/where_like.php
@@ -16,6 +16,8 @@
 
 namespace local_sqlquerybuilder\query\where;
 
+use local_sqlquerybuilder\contracts\like_options;
+
 /**
  * Compares a column with a string
  *

--- a/classes/query/wherepart.php
+++ b/classes/query/wherepart.php
@@ -38,7 +38,6 @@ use local_sqlquerybuilder\query\where\where_like;
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class wherepart extends condition {
-
     public function get_sql(): string {
         if (empty($this->conditionparts)) {
             return '';

--- a/classes/query/wherepart.php
+++ b/classes/query/wherepart.php
@@ -37,121 +37,14 @@ use local_sqlquerybuilder\query\where\where_like;
  * @copyright   2025 Konrad Ebel <despair2400@proton.me>
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class wherepart implements i_expression {
-    protected array $whereconditions = [];
-
-    public function where(string $column, string $operator, mixed $value, bool $negate = false): void {
-        if ($operator == 'like') {
-            $this->whereconditions[] = new where_like($column, $value, $negate);
-        } else {
-            $this->whereconditions[] = new where_comparison($column, $operator, $value, $negate);
-        }
-    }
-
-    public function where_column(string $column, string $operator, string $othercolumn, bool $negate = false): void {
-        $this->whereconditions[] = new where_column_comparison($column, $operator, $othercolumn, $negate);
-    }
-
-    public function or_where(string $column, string $operator, mixed $value, bool $negate = false): void {
-        $this->where($column, $operator, $value, $negate);
-        $this->combine_last_two_by_or();
-    }
-
-    public function where_not(string $column, string $operator, mixed $value): void {
-        $this->where($column, $operator, $value, true);
-    }
-
-    public function or_where_not(string $column, string $operator, mixed $value): void {
-        $this->or_where($column, $operator, $value, true);
-    }
-
-    public function where_fulltext(string $column, string $value, bool $negate = false): void {
-        $this->whereconditions[] = new where_fulltext($column, $value, $negate);
-    }
-
-    public function where_fulltext_not(string $column, string $value): void {
-        $this->whereconditions[] = new where_fulltext($column, $value, true);
-    }
-
-    public function where_like(string $column, string $value, ?like_options $options = null, bool $negate = false): void {
-        $this->whereconditions[] = new where_like($column, $value, $negate, $options);
-    }
-
-    public function where_not_like(string $column, string $value, ?like_options $options = null): void {
-        $this->where_like($column, $value, $options, true);
-    }
-
-    public function where_null(string $column): void {
-        $this->whereconditions[] = new where_is_null($column);
-    }
-
-    public function or_where_null(string $column): void {
-        $this->where_null($column);
-        $this->combine_last_two_by_or();
-    }
-
-    public function where_notnull(string $column): void {
-        $this->whereconditions[] = new where_is_null($column, true);
-    }
-
-    public function or_where_notnull(string $column): void {
-        $this->where_notnull($column);
-        $this->combine_last_two_by_or();
-    }
-
-    public function where_in(string $column, array|i_query $values, bool $negate = false): void {
-        $this->whereconditions[] = new where_in($column, $values, $negate);
-    }
-
-    public function where_not_in(string $column, array|i_query $values): void {
-        $this->where_in($column, $values, true);
-    }
-
-    private function combine_last_two_by_or(): void {
-        if (count($this->whereconditions) < 2) {
-            return;
-        }
-
-        $aclause = array_pop($this->whereconditions);
-        $bclause = array_pop($this->whereconditions);
-        $orclause = null;
-
-        if ($aclause instanceof or_where_group) {
-            $aclause->add_clauses($bclause);
-            $orclause = $aclause;
-        } else {
-            $orclause = new or_where_group(
-                $aclause,
-                $bclause,
-            );
-        }
-
-        $this->whereconditions[] = $orclause;
-    }
-
-    public function where_currently_active(string $columntimestart, string $columntimeend): void {
-        $currenttime = di::get(clock::class)->time();
-
-        $this->where_null($columntimestart);
-        $this->or_where($columntimestart, '<=', $currenttime);
-        $this->where_null($columntimeend);
-        $this->or_where($columntimeend, '>=', $currenttime);
-    }
+class wherepart extends condition {
 
     public function get_sql(): string {
-        $whereclause = ' WHERE ';
-
-        if (empty($this->whereconditions)) {
+        if (empty($this->conditionparts)) {
             return '';
         }
 
-        $whereclause .= implode(' AND ', $this->whereconditions);
-        $whereclause .= ' ';
+        $whereclause = ' WHERE ' . parent::get_sql();
         return $whereclause;
-    }
-
-    public function get_params(): array {
-        $params = array_map(fn (where_expression $expression) => $expression->get_params(), $this->whereconditions);
-        return array_merge(...$params);
     }
 }

--- a/tests/sqlgeneration_test.php
+++ b/tests/sqlgeneration_test.php
@@ -19,6 +19,7 @@ namespace local_sqlquerybuilder;
 use core\di;
 use advanced_testcase;
 use local_sqlquerybuilder\contracts\i_db;
+use local_sqlquerybuilder\contracts\i_condition;
 
 /**
  * Testing the SQL generation
@@ -296,6 +297,19 @@ final class sqlgeneration_test extends advanced_testcase {
 
         $actual = $this->db->table('unknown')
             ->where_in('field', $latestcourses);
+
+        $this->assertEquals($expected, $actual->get_sql());
+        $this->assertEquals($expectedparams, $actual->get_params());
+    }
+
+    public function test_subquery_join_where_in(): void {
+        $expected = "SELECT * FROM {unknown} JOIN {course} ON id IN (?,?,?)";
+        $expectedparams = [1, 2, 3];
+
+        $actual = $this->db->table('unknown')
+            ->join('course', function (i_condition $condition) {
+                $condition->where_in('id', [1, 2, 3]);
+            });
 
         $this->assertEquals($expected, $actual->get_sql());
         $this->assertEquals($expectedparams, $actual->get_params());


### PR DESCRIPTION
Conditions can now be created by callables:
$this->db->table('unknown')
              ->join('course', function (i_condition $condition) {
                  $condition->where_in('id', [1, 2, 3]);
              });
              
Or by using the short variant:
$this->db->table('enrol', 'e')
              ->distinct()
              ->join('user_enrolments', ['ue.enrolid', '=', 'e.id'], 'ue')